### PR TITLE
fix invalid check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ vignettes/*.pdf
 NEWS.html
 rstpm2*.tar.gz
 ..Rcheck
+.Rproj.user

--- a/R/pm2-3.R
+++ b/R/pm2-3.R
@@ -775,12 +775,8 @@ gsm <- function(formula, data, smooth.formula = NULL, smooth.args = NULL,
     }
     Z.formula <- Z
     ##
-    left <- deparse(formula)
     tf <- terms.formula(smooth.formula, specials = c("s", "te"))
     terms <- attr(tf, "term.labels")
-    right <- paste0(terms, collapse = "+")
-    ## fullformula <- as.formula(paste0(left, "+", right), env = parent.frame())
-    rm(left,right) # tidy up
     ##
     ##
     ## Different models:
@@ -966,7 +962,7 @@ gsm <- function(formula, data, smooth.formula = NULL, smooth.args = NULL,
         init <- coef(lm.obj)
     } else {
         ## ASSUMES ONLY ONE-DIMENSIONAL FRAILTY
-        stopifnot(length(init)+frailty == length(coef(lm.obj)))
+        stopifnot(length(init) == length(coef(lm.obj)))
     }
     ##
     ## set up mf and wt
@@ -1072,7 +1068,7 @@ gsm <- function(formula, data, smooth.formula = NULL, smooth.args = NULL,
         if (ncol(Z)>2) stop("Current implementation only allows for one or two random effects")
         if (ncol(Z)==2) {
             init <- c(init,logtheta1=logtheta,corrtrans=0,logtheta2=logtheta)
-        } else init <- c(init, logtheta=logtheta)
+        } else init <- c(init, logtheta=unname(logtheta))
     } else {
         Z.formula <- NULL
         Z <- matrix(1,1,1)

--- a/tests/testthat/test_base.R
+++ b/tests/testthat/test_base.R
@@ -57,6 +57,19 @@ test_that("base", {
     expect_eps(coef(fit)[2], 0.93819784, 1e-5)
     expect_eps(coef(fit)[6], 0.02906888, 1e-5)
 })
+##
+test_that("providing initial values with frailty works", {
+  dat <- data.frame(
+    y     = c(1, 2, 1, 2, 1, 1), 
+    event = c(0, 1, 1, 0, 1, 1),
+    grp   = c(1, 1, 2, 2, 3, 3))
+  
+  fit     <- gsm(Surv(y, event) ~ 1, dat, df = 1, cluster = dat$grp)
+  fit_new <- gsm(Surv(y, event) ~ 1, dat, df = 1, cluster = dat$grp, 
+                 init = head(coef(fit), -1), logtheta = tail(coef(fit), 1))
+  
+  expect_equal(coef(fit), coef(fit_new))
+})
 
 context("pstpm2")
 ##


### PR DESCRIPTION
Before the new test gave 

```r
dat <- data.frame(
    y     = c(1, 2, 1, 2, 1, 1), 
    event = c(0, 1, 1, 0, 1, 1),
    grp   = c(1, 1, 2, 2, 3, 3))
  
fit     <- gsm(Surv(y, event) ~ 1, dat, df = 1, cluster = dat$grp)
fit_new <- gsm(Surv(y, event) ~ 1, dat, df = 1, cluster = dat$grp, 
               init = head(coef(fit), -1), logtheta = tail(coef(fit), 1))
#R> Error in gsm(Surv(y, event) ~ 1, dat, df = 1, cluster = dat$grp, init = head(coef(fit),  : 
#R>   length(init) + frailty == length(coef(lm.obj)) is not TRUE
```

but the `stopifnot` check was not correct.