### PR TITLE
Optionally skip test requiring 'eha'

### DIFF
--- a/tests/testthat/test_delayed.R
+++ b/tests/testthat/test_delayed.R
@@ -32,6 +32,8 @@ test_that("pstpm2", {
 context("Delayed entry - aft")
 ##
 test_that("All values zero or one", {
+    skip_if_not_installed("eha")
+
     brcancer2 <- transform(rstpm2::brcancer,startTime=0)
     fit0 <- aft(Surv(rectime,censrec==1)~hormon,data=brcancer2)
     fit1 <- aft(Surv(startTime,rectime,censrec==1)~hormon,data=brcancer2)


### PR DESCRIPTION
My understanding is without {eha} this test fails opaquely:

```
── Error (test_delayed.R:40:5): All values zero or one ─────────────────────────
Error in `minuslogl(c(`nsx(logtstar, df, intercept = TRUE)1` = -16.9873056648642, `nsx(logtstar, df, intercept = TRUE)2` = -18.6584897751695, `nsx(logtstar, df, intercept = TRUE)3` = -4.24793872566632))`: length(beta) == length(args$init) is not TRUE
Backtrace:
    ▆
 1. └─rstpm2::aft(...) at test_delayed.R:40:5
 2.   └─rstpm2 (local) optim_step(control$use.gr)
 3.     └─bbmle::mle2(...)
 4.       └─bbmle (local) objectivefunction(start)
 5.         ├─base::do.call("minuslogl", args)
 6.         └─rstpm2 (local) minuslogl(`<dbl>`)
 7.           └─base::stopifnot(is.numeric(beta), length(beta) == length(args$init))
```

Gemini diagnosed this:

The error occurs because the delayed entry AFT models in rstpm2 rely on the eha package to provide proper initial values for model parameters.

When eha is not installed in the local environment, rstpm2 uses an un-named vector of zeros as a fallback for the main effect coefficients. This fallback creates an initial value vector (`args$init`) where some names are missing/`NULL`. When passed to `bbmle::mle2()`, the optimizer drops or re-formats the un-named parameters, causing the parameter vector passed to the negative log-likelihood function to have a different length than the expected initial vector, triggering the `length(beta) == length(args$init)` assertion failure.